### PR TITLE
Remove sudo access in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,5 @@ language: go
 branches:
   only:
   - master
-sudo: false
 notifications:
   email: false


### PR DESCRIPTION
What:

Travis is deprecating the use of sudo: false in .travis files
Why:

They are combining their two Linux builds environments to a “single” VM based solution.
When:

03 December, 2018 - We will start randomly sampling projects on both travis-ci.org and travis-ci.com to move them permanently to using the virtual-machine-based infrastructure for all builds. The projects will be migrated incrementally over a few days
07 December, 2018 - All projects that use a Linux build environment will be fully migrated to using the same Linux infrastructure, which runs builds in virtual-machines.
More info: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration